### PR TITLE
Add useTransactions option

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,4 +2,4 @@
 
 docker-compose build
 docker-compose down -v
-docker-compose -f docker-compose.yaml run --rm pg-access-apply
+docker-compose -f docker-compose.yaml run --rm pg-access-apply npm run -- test "$@"


### PR DESCRIPTION
Currently only uses transactions for modifications (except `CREATE DATABASE`) so changes are either successfully applied, or rolled-back.